### PR TITLE
Fixes mistaken it's for its

### DIFF
--- a/_posts/2016-07-19-c.html
+++ b/_posts/2016-07-19-c.html
@@ -10,7 +10,7 @@ awslink: https://s3-us-west-1.amazonaws.com/vimgifs/c.gif
   <div class="pa3">
     <h2 class="f5">{{page.title}}</h2>
     <code class="lh-copy">
-      c stands for change and doesn't do anything on it's own.<br><br>
+      c stands for change and doesn't do anything on its own.<br><br>
       cc will change the entire line (it deletes the whole line and drops you into insert mode).
       C will delete from your cursor to the end of the line and drop you into insert mode.<br><br>
     </code>

--- a/_posts/2016-07-19-d.html
+++ b/_posts/2016-07-19-d.html
@@ -10,7 +10,7 @@ awslink: https://s3-us-west-1.amazonaws.com/vimgifs/d.gif
   <div class="pa3">
     <h2 class="f5">{{page.title}}</h2>
     <code class="lh-copy">
-      d stands for delete. It doesn't do anything on it's own.<br><br>
+      d stands for delete. It doesn't do anything on its own.<br><br>
       dd will delete the entire line<br>
       D will delete from your cursor through the end of the line
     </code>

--- a/_posts/2016-07-19-z.html
+++ b/_posts/2016-07-19-z.html
@@ -10,7 +10,7 @@ awslink: https://s3-us-west-1.amazonaws.com/vimgifs/zplus.gif
   <div class="pa3">
     <h2 class="f5">{{page.title}}</h2>
     <code class="lh-copy">
-      z doesn't do anything on it's own. But it pairs with a number of other things.
+      z doesn't do anything on its own. But it pairs with a number of other things.
       It is used for redrawing the screen, saving and quitting, as well as manipulating folds.<br><br>
 
       Here we show z+ and how it redraws the first line out of


### PR DESCRIPTION
`It's` is a contraction of `it is`. `Its` does not require a apostrophe to
show possession as it is a possessive pronoun.
