### PR TITLE
Create a related gifs partial

### DIFF
--- a/source/gifs/c.html.erb
+++ b/source/gifs/c.html.erb
@@ -8,6 +8,10 @@ further_reading:
     url: http://vimdoc.sourceforge.net/htmldoc/change.html#cc
   - title: C
     url: http://vimdoc.sourceforge.net/htmldoc/change.html#C
+related:
+  - cit
+  - ctgt
+  - cw 
 ---
 
 c stands for change and doesn't do anything on its own.<br><br>

--- a/source/layouts/gif.erb
+++ b/source/layouts/gif.erb
@@ -15,6 +15,8 @@
     <footer class="pv4 ph3 mw7 center gray" style="font-size:.75rem;">
       <a href="https://twitter.com/share" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
     </footer>
+
+    <%= partial "partials/related", locals: { related: current_page.data.related } %>
   </article>
   <%= partial "partials/archives" %>
 <% end %>

--- a/source/partials/_related.html.erb
+++ b/source/partials/_related.html.erb
@@ -1,14 +1,17 @@
+<% if !related.nil? %>
 <article class="pv4 bt b--black-10">
   <div class="mw7 center ph3">
     <h1 class="f4 mb4 fw4">Related Gifs</h1>
     <ul class="list mt1 pl0 ml0">
-      <% links.each do |link| %>
+      <% related.each do |related| %>
+        <% article = sitemap.find_resource_by_path("gifs/#{related}.html") %>
         <li class="pl0 mb4 mr4 dib">
-          <a href="<%= link.url %>" title="<%= link.title %>" class="link db dim black-60">
-            <span class="f5 fw6 db lh-copy"><%= link.title %></span>
+          <a href="<%= article.url %>" title="<%= article.title %>" class="link db dim black-60">
+            <span class="f5 fw6 db lh-copy"><%= article.title %></span>
           </a>
         </li>
       <% end %>
     </ul>
   </div>
 </article>
+<% end %>


### PR DESCRIPTION
This feature adds the ability to add some yaml at the top of an article and have the related articles get pulled through into a partial where we can then link to.

This is what the yaml looks like

``` yaml

---
related:
  - cit
  - ctgt
  - cw 

---
```

All this is, is a YAML list and each item on the list is the name of an article (the file name to be more precisely). 

We then loop over that and render out links in the order of the list.

This is the current design:
<img width="829" alt="screen shot 2016-07-25 at 19 39 25" src="https://cloud.githubusercontent.com/assets/878503/17112811/85474316-529f-11e6-80ef-7bc6fb2f5208.png">

It probably needs updating to something to be a bit more inviting :)
