### PR TITLE
Adding link tag to Atom feed for feed detection

### DIFF
--- a/source/partials/_head.html.erb
+++ b/source/partials/_head.html.erb
@@ -14,6 +14,7 @@
     <meta name="description" content="If you can watch gifs you can learn vim">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag 'tachyons.min' %>
+    <%= auto_discovery_link_tag :atom, "/feed.xml" %>
     <style>
       img { width: 100%; max-width: 100%; }
       .f7 { font-size: 12px; }


### PR DESCRIPTION
Love this site!  I wanted to make sure the RSS feed was more accessible so people didn't have to poke around the source to find it.  This should enable RSS feed detectors (such as [this one for Chrome](https://chrome.google.com/webstore/detail/rss-subscription-extensio/nlbjncdgjeocebhnmkbbbdekmmmcbfjd?hl=en)) to detect the Atom feed for easy subscription.

I'm not sure how to run the site locally, however, so this is untested.
