### PR TITLE
Use correct feed tag

### DIFF
--- a/source/feed.xml.builder
+++ b/source/feed.xml.builder
@@ -11,7 +11,7 @@ xml.feed 'xmlns' => 'http://www.w3.org/2005/Atom' do
 
   blog.articles[0...50].each do |article|
     xml.entry do
-      xml.title article.title
+      xml.title h(article.title)
       xml.link 'rel' => 'alternate', 'href' => URI.join(site_url, article.url)
       xml.id URI.join(site_url, article.url)
       xml.published article.date.to_time.iso8601

--- a/source/partials/_head.html.erb
+++ b/source/partials/_head.html.erb
@@ -14,7 +14,7 @@
     <meta name="description" content="If you can watch gifs you can learn vim">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag 'tachyons.min' %>
-    <%= auto_discovery_link_tag :atom, "/feed.xml" %>
+    <%= feed_tag :atom, "/feed.xml", title: "vimgifs Atom Feed" %>
     <style>
       img { width: 100%; max-width: 100%; }
       .f7 { font-size: 12px; }


### PR DESCRIPTION
The middleman documentation is like searching for a needle while swimming through a sea of needles! I was using a tag from middleman 3 this was breaking the build. Fixed and updated now. I have also escaped the url strings for title as it has been breaking the feed
